### PR TITLE
[FIX] tournamentSize -> roomInfo 사용

### DIFF
--- a/src/v1/sockets/waiting/handlers/custom.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/custom.socket.handler.ts
@@ -19,6 +19,7 @@ import SocketCache from '../../../storage/cache/socket.cache.js';
 import { FastifyBaseLogger } from 'fastify';
 import UserServiceClient from '../../../client/user.service.client.js';
 import { tournamentRequestProducer } from '../../../kafka/producers/tournament.producer.js';
+import { tournamentSizeType } from '../schemas/tournament.schema.js';
 
 export default class CustomSocketHandler {
   constructor(
@@ -124,8 +125,9 @@ export default class CustomSocketHandler {
     }
 
     const userIds = await this.customRoomCache.getUsersInRoom(message.roomId);
+    const roomInfo = await this.customRoomCache.getRoomInfo(message.roomId);
     await tournamentRequestProducer({
-      size: message.tournamentSize,
+      size: roomInfo.maxPlayers as tournamentSizeType,
       mode: 'CUSTOM',
       players: userIds,
       timestamp: new Date().toISOString(),

--- a/src/v1/sockets/waiting/schemas/custom-game.schema.ts
+++ b/src/v1/sockets/waiting/schemas/custom-game.schema.ts
@@ -37,7 +37,6 @@ export type customStartType = TypeOf<typeof customStartSchema>;
 
 export const customStartSchema = z.object({
   roomId: z.string(),
-  tournamentSize: tournamentSizeSchema,
 });
 
 export const inviteMessageSchema = z.object({

--- a/src/v1/sockets/waiting/schemas/tournament.schema.ts
+++ b/src/v1/sockets/waiting/schemas/tournament.schema.ts
@@ -1,7 +1,5 @@
 import { TypeOf, z } from 'zod';
 
-export type tournamentSizeType = TypeOf<typeof tournamentSizeSchema>;
-
 export const tournamentSizeSchema = z.union([
   z.literal(2),
   z.literal(4),
@@ -9,6 +7,8 @@ export const tournamentSizeSchema = z.union([
   z.literal(16),
 ]);
 
-export type tournamentModeType = TypeOf<typeof tournamentModeSchema>;
+export type tournamentSizeType = TypeOf<typeof tournamentSizeSchema>;
 
 export const tournamentModeSchema = z.enum(['AUTO', 'CUSTOM']);
+
+export type tournamentModeType = TypeOf<typeof tournamentModeSchema>;


### PR DESCRIPTION
## 📝 작업 내용

- `custom-start`이벤트 발생시 kafka producer를 통해 토너먼트 생성을 요청합니다.
- 이때 인자로 `roomId`뿐만아니라 `tournamentSize` 까지 클라이언트를 통해 입력받고 있습니다.
- `roomId`를 통해 해당 방의 인원 수를 알 수 있어, `roomId`를 통해 토너먼트의 크기를 가져와서 처리하였습니다.