### PR TITLE
[REFACTOR] 게임초대시 토너먼트 크기를 포함하여 전달

### DIFF
--- a/src/v1/sockets/waiting/handlers/custom.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/custom.socket.handler.ts
@@ -68,8 +68,11 @@ export default class CustomSocketHandler {
     }
 
     const hostId = await this.customRoomCache.getHostId(message.roomId);
-    const hostUser = await this.userServiceClient.getUserInfo(hostId);
-    const roomInfo = await this.customRoomCache.getRoomInfo(message.roomId);
+    const [hostUser, roomInfo] = await Promise.all([
+      this.userServiceClient.getUserInfo(hostId),
+      this.customRoomCache.getRoomInfo(message.roomId),
+    ]);
+
     const response: InviteMessageType = {
       roomId: message.roomId,
       tournamentSize: tournamentSizeSchema.parse(roomInfo.maxPlayers),

--- a/src/v1/sockets/waiting/handlers/custom.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/custom.socket.handler.ts
@@ -19,7 +19,7 @@ import SocketCache from '../../../storage/cache/socket.cache.js';
 import { FastifyBaseLogger } from 'fastify';
 import UserServiceClient from '../../../client/user.service.client.js';
 import { tournamentRequestProducer } from '../../../kafka/producers/tournament.producer.js';
-import { tournamentSizeType } from '../schemas/tournament.schema.js';
+import { tournamentSizeSchema } from '../schemas/tournament.schema.js';
 
 export default class CustomSocketHandler {
   constructor(
@@ -69,8 +69,10 @@ export default class CustomSocketHandler {
 
     const hostId = await this.customRoomCache.getHostId(message.roomId);
     const hostUser = await this.userServiceClient.getUserInfo(hostId);
+    const roomInfo = await this.customRoomCache.getRoomInfo(message.roomId);
     const response: InviteMessageType = {
       roomId: message.roomId,
+      tournamentSize: tournamentSizeSchema.parse(roomInfo.maxPlayers),
       hostId: hostUser.id,
       hostName: hostUser.nickname,
       hostAvatarUrl: hostUser.avatarUrl,
@@ -127,7 +129,7 @@ export default class CustomSocketHandler {
     const userIds = await this.customRoomCache.getUsersInRoom(message.roomId);
     const roomInfo = await this.customRoomCache.getRoomInfo(message.roomId);
     await tournamentRequestProducer({
-      size: roomInfo.maxPlayers as tournamentSizeType,
+      size: tournamentSizeSchema.parse(roomInfo.maxPlayers),
       mode: 'CUSTOM',
       players: userIds,
       timestamp: new Date().toISOString(),

--- a/src/v1/sockets/waiting/schemas/custom-game.schema.ts
+++ b/src/v1/sockets/waiting/schemas/custom-game.schema.ts
@@ -41,6 +41,7 @@ export const customStartSchema = z.object({
 
 export const inviteMessageSchema = z.object({
   roomId: z.string(),
+  tournamentSize: tournamentSizeSchema,
   hostId: z.number(),
   hostName: z.string(),
   hostAvatarUrl: z.string().url(),


### PR DESCRIPTION
## 📝 작업 내용

게임 초대시 tournamentSize와 함께 보내 토너먼의 사이즈를 보내어 클라이언트가 미리 토너먼트의 크기를 알 수 있도록 변경하였습니다.

초대시 다음과 같은 정보가 클라이언트에게 전달됩니다.
<img width="442" alt="image" src="https://github.com/user-attachments/assets/f3a81f51-b803-4417-b066-bf2d3ef6be06" />
