### PR TITLE
[FEAT] AUTO게임 큐에 입장시, 대기방 업데이트 이벤트 추가

### DIFF
--- a/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
@@ -38,7 +38,6 @@ export default class AutoSocketHandler {
     const user = await this.userServiceClient.getUserInfo(socket.data.userId);
 
     const response = roomUpdateSchema.parse({
-      roomId: '',
       users: [
         {
           id: user.id,

--- a/src/v1/sockets/waiting/schemas/custom-game.schema.ts
+++ b/src/v1/sockets/waiting/schemas/custom-game.schema.ts
@@ -53,7 +53,7 @@ export const roomUpdateUserSchema = z.object({
   id: z.number(),
   nickname: z.string(),
   avatarUrl: z.string().url(),
-  isHost: z.boolean(),
+  isHost: z.boolean().default(false),
 });
 export type RoomUpdateUserType = TypeOf<typeof roomUpdateUserSchema>;
 

--- a/src/v1/sockets/waiting/schemas/custom-game.schema.ts
+++ b/src/v1/sockets/waiting/schemas/custom-game.schema.ts
@@ -58,7 +58,7 @@ export const roomUpdateUserSchema = z.object({
 export type RoomUpdateUserType = TypeOf<typeof roomUpdateUserSchema>;
 
 export const roomUpdateSchema = z.object({
-  roomId: z.string(),
+  roomId: z.string().optional(),
   users: z.array(roomUpdateUserSchema),
 });
 export type RoomUpdateType = TypeOf<typeof roomUpdateSchema>;


### PR DESCRIPTION
## 📝 작업 내용

- 대기 큐에 입장할 때, `waiting-room-update`이벤트를 발생시켜 서버로부터 사용자의 정보를 전달할 수 있도록 변경하였습니다.