### PR TITLE
[FEATURE] auto 모드에서 매칭 대기중 대기열 상태 전송 로직 구현

### DIFF
--- a/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
@@ -1,4 +1,4 @@
-import { Socket } from 'socket.io';
+import { Namespace, Socket } from 'socket.io';
 import {
   autoJoinSchema,
   autoJoinSchemaType,
@@ -12,12 +12,15 @@ import { roomUpdateSchema } from '../schemas/custom-game.schema.js';
 import { WAITING_SOCKET_EVENTS } from '../waiting.event.js';
 import UserServiceClient from '../../../client/user.service.client.js';
 import { tournamentSizeSchema } from '../schemas/tournament.schema.js';
+import SocketCache from '../../../storage/cache/socket.cache.js';
 
 export default class AutoSocketHandler {
   constructor(
     private readonly waitingQueueCache: WaitingQueueCache,
     private readonly logger: FastifyBaseLogger,
     private readonly userServiceClient: UserServiceClient,
+    private readonly socketCache: SocketCache,
+    private readonly waitingNamespace: Namespace,
   ) {}
 
   async joinAutoRoom(socket: Socket, payload: autoJoinSchemaType) {
@@ -39,20 +42,9 @@ export default class AutoSocketHandler {
     await this.waitingQueueCache.addUser(tournamentSize, socket.data.userId);
     if (await this.waitingQueueCache.isQueueReady(tournamentSize)) {
       await this.startTournament(tournamentSize);
+      return;
     }
-
-    const user = await this.userServiceClient.getUserInfo(socket.data.userId);
-    const response = roomUpdateSchema.parse({
-      users: [
-        {
-          id: user.id,
-          nickname: user.nickname,
-          avatarUrl: user.avatarUrl,
-          isHost: false,
-        },
-      ],
-    });
-    socket.emit(WAITING_SOCKET_EVENTS.WAITING_ROOM_UPDATE, response);
+    await this.sendWaitingRoomUpdates(tournamentSize);
   }
 
   async leaveAutoRoom(socket: Socket, payload: autoLeaveSchemaType) {
@@ -74,6 +66,8 @@ export default class AutoSocketHandler {
     socket.emit(WAITING_SOCKET_EVENTS.LEAVE_SUCCESS, {
       message: `Successfully left the queue for ${tournamentSize} tournament`,
     });
+
+    await this.sendWaitingRoomUpdates(tournamentSize);
   }
 
   async leaveAllAutoRooms(socket: Socket) {
@@ -95,5 +89,53 @@ export default class AutoSocketHandler {
       timestamp: new Date().toISOString(),
     });
     this.logger.info(`Tournament request sent for size ${tournamentSize} with users: ${userIds}`);
+  }
+
+  private async sendWaitingRoomUpdates(tournamentSize: number) {
+    const userIds = await this.waitingQueueCache.getUsersInQueue(tournamentSize);
+    if (userIds.length === 0) {
+      this.logger.error(`No users found in the waiting queue for size ${tournamentSize}`);
+      throw new Error(`No users found in the waiting queue for size ${tournamentSize}`);
+    }
+
+    const userInfoPromises = userIds.map((userId) => this.userServiceClient.getUserInfo(userId));
+    const users = await Promise.all(userInfoPromises);
+
+    for (const currentUser of users) {
+      const maskedUsers = users.map((user) => {
+        if (currentUser.id !== user.id) {
+          return {
+            id: 0,
+            nickname: '???',
+          };
+        }
+        return user;
+      });
+      const response = roomUpdateSchema.parse({
+        users: maskedUsers,
+      });
+      const socket = await this.findSocketByUserId(currentUser.id);
+      socket.emit(WAITING_SOCKET_EVENTS.WAITING_ROOM_UPDATE, response);
+    }
+  }
+
+  private async findSocketByUserId(userId: number): Promise<Socket> {
+    const socketId = await this.socketCache.getSocketId({
+      namespace: 'waiting',
+      userId: userId,
+    });
+
+    if (!socketId) {
+      this.logger.error(`Socket ID not found for user ${userId}`);
+      throw new Error(`Socket ID not found for user ${userId}`);
+    }
+
+    const socket = this.waitingNamespace.sockets.get(socketId);
+    if (!socket) {
+      this.logger.error(`Socket not found for user ${userId} with ID ${socketId}`);
+      throw new Error(`Socket not found for user ${userId}`);
+    }
+
+    return socket;
   }
 }

--- a/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
@@ -107,6 +107,7 @@ export default class AutoSocketHandler {
             return {
               id: 0,
               nickname: '???',
+              avatarUrl: 'https://null.com/null.png',
             };
           }
           return user;

--- a/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
+++ b/src/v1/sockets/waiting/handlers/auto.socket.handler.ts
@@ -94,8 +94,7 @@ export default class AutoSocketHandler {
   private async sendWaitingRoomUpdates(tournamentSize: number) {
     const userIds = await this.waitingQueueCache.getUsersInQueue(tournamentSize);
     if (userIds.length === 0) {
-      this.logger.error(`No users found in the waiting queue for size ${tournamentSize}`);
-      throw new Error(`No users found in the waiting queue for size ${tournamentSize}`);
+      return;
     }
 
     const userInfoPromises = userIds.map((userId) => this.userServiceClient.getUserInfo(userId));

--- a/src/v1/sockets/waiting/schemas/custom-game.schema.ts
+++ b/src/v1/sockets/waiting/schemas/custom-game.schema.ts
@@ -52,7 +52,7 @@ export type InviteMessageType = TypeOf<typeof inviteMessageSchema>;
 export const roomUpdateUserSchema = z.object({
   id: z.number(),
   nickname: z.string(),
-  avatarUrl: z.string().url().optional(),
+  avatarUrl: z.string().url(),
   isHost: z.boolean().default(false),
 });
 export type RoomUpdateUserType = TypeOf<typeof roomUpdateUserSchema>;

--- a/src/v1/sockets/waiting/schemas/custom-game.schema.ts
+++ b/src/v1/sockets/waiting/schemas/custom-game.schema.ts
@@ -52,7 +52,7 @@ export type InviteMessageType = TypeOf<typeof inviteMessageSchema>;
 export const roomUpdateUserSchema = z.object({
   id: z.number(),
   nickname: z.string(),
-  avatarUrl: z.string().url(),
+  avatarUrl: z.string().url().optional(),
   isHost: z.boolean().default(false),
 });
 export type RoomUpdateUserType = TypeOf<typeof roomUpdateUserSchema>;

--- a/src/v1/sockets/waiting/waiting.namespace.ts
+++ b/src/v1/sockets/waiting/waiting.namespace.ts
@@ -85,7 +85,9 @@ export function startWaitingNamespace(namespace: Namespace) {
         await autoSocketHandler.leaveAllAutoRooms(socket);
         await customSocketHandler.leaveRoom(socket);
       } catch (error) {
-        logger.error(`Error during disconnect: ${error instanceof Error ? error.message : error}`);
+        logger.error(
+          `Error during disconnect for socket ${socket.id} and user ${userId}: ${error instanceof Error ? error.message : error}`,
+        );
       }
     });
 

--- a/src/v1/sockets/waiting/waiting.namespace.ts
+++ b/src/v1/sockets/waiting/waiting.namespace.ts
@@ -74,15 +74,19 @@ export function startWaitingNamespace(namespace: Namespace) {
     registerAutoEvents(socket, autoSocketHandler, logger);
     registerCustomEvents(socket, customSocketHandler, logger);
 
-    socket.on('disconnect', () => {
-      logger.info(`🔴 [/waiting] Disconnected: ${socket.id}`);
-      socketCache.deleteSocketId({
-        namespace: 'waiting',
-        userId: userId,
-      });
+    socket.on('disconnect', async () => {
+      try {
+        logger.info(`🔴 [/waiting] Disconnected: ${socket.id}`);
+        await socketCache.deleteSocketId({
+          namespace: 'waiting',
+          userId: userId,
+        });
 
-      autoSocketHandler.leaveAllAutoRooms(socket);
-      customSocketHandler.leaveRoom(socket);
+        await autoSocketHandler.leaveAllAutoRooms(socket);
+        await customSocketHandler.leaveRoom(socket);
+      } catch (error) {
+        logger.error(`Error during disconnect: ${error instanceof Error ? error.message : error}`);
+      }
     });
 
     socket.on('error', (error: Error) => {

--- a/src/v1/storage/cache/waiting.queue.cache.ts
+++ b/src/v1/storage/cache/waiting.queue.cache.ts
@@ -68,4 +68,16 @@ export default class WaitingQueueCache {
     const users = await this.redisClient.lrange(key, 0, queueLength - 1);
     return users.includes(userId.toString());
   }
+
+  async getUsersInQueue(tournamentSize: number): Promise<number[]> {
+    const key = this.getQueueKey(tournamentSize);
+
+    const queueLength = await this.redisClient.llen(key);
+    if (queueLength === 0) {
+      return [];
+    }
+
+    const userIds = await this.redisClient.lrange(key, 0, queueLength - 1);
+    return userIds.map((id) => Number(id));
+  }
 }


### PR DESCRIPTION
## 📝 작업 내용

- AUTO 모드에서 매칭을 시작하면 해당 토너먼트에 필요한 유저들이 대기열에 존재해야 매칭이 완료됩니다.
- 그 과정에서 대기중인 유저들을 위해 현재 몇명이 대기열에 존재하는지 보여주는 기능을 추가하였습니다.

- 예를 들어, 4명이 필요한 토너먼트에 참여했고, 해당 대기열엔 2명이 존재한다고 가정하면,
```json
{
    "users": [
        {
            "id": 0,
            "nickname": "???",
            "isHost": false
        },
        {
            "id": 222,
            "nickname": "mynickname",
            "avatarUrl": "http://localhost:3000/avatars/default.png/avatars/default.png",
            "isHost": false
        }
    ]
}
```

다음과 같이 자신의 정보를 제외한 다른 `유저의 id는 0`으로 `nickname은 "???"`로 마스킹되어 전달됩니다.
