### PR TITLE
[FEATURE] 게임 결과 저장 및 토너먼트 반영 로직 구현

### DIFF
--- a/src/server-utils.ts
+++ b/src/server-utils.ts
@@ -16,7 +16,7 @@ export function getLoggerOptions() {
   return {
     level: 'info',
     transport: {
-      target: 'pino-pretty',
+      target: process.env.NODE_ENV === 'dev' ? 'pino-pretty' : 'pino',
       options: {
         translateTime: 'yyyy-mm-dd HH:MM:ss',
         ignore: 'pid,hostname',

--- a/src/server-utils.ts
+++ b/src/server-utils.ts
@@ -13,19 +13,16 @@ export function createServer() {
 }
 
 export function getLoggerOptions() {
-  if (process.stdout.isTTY) {
-    return {
-      level: 'info',
-      transport: {
-        target: 'pino-pretty',
-        options: {
-          translateTime: 'HH:MM:ss Z',
-          ignore: 'pid,hostname',
-        },
+  return {
+    level: 'info',
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        translateTime: 'HH:MM:ss Z',
+        ignore: 'pid,hostname',
       },
-    };
-  }
-  return { level: process.env.FASTIFY_LOG_LEVEL || 'error' };
+    },
+  };
 }
 
 export async function startServer(server: FastifyInstance) {

--- a/src/server-utils.ts
+++ b/src/server-utils.ts
@@ -18,7 +18,7 @@ export function getLoggerOptions() {
     transport: {
       target: 'pino-pretty',
       options: {
-        translateTime: 'HH:MM:ss Z',
+        translateTime: 'yyyy-mm-dd HH:MM:ss',
         ignore: 'pid,hostname',
       },
     },

--- a/src/v1/kafka/consumers/match.topic.service.ts
+++ b/src/v1/kafka/consumers/match.topic.service.ts
@@ -41,7 +41,12 @@ export default class MatchTopicService {
   async handleMatchResult(messageValue: HandleMatchResultType): Promise<void> {
     matchResultMessageSchema.parse(messageValue);
 
-    // TODO: 매치 결과 DB에 저장 및 다음 라운드 반영
+    await this.matchRepository.update(messageValue.matchId, {
+      player1Score: messageValue.score.player1,
+      player2Score: messageValue.score.player2,
+      winner: messageValue.winnerId,
+      status: 'FINISHED',
+    });
 
     const match = await this.matchRepository.findById(messageValue.matchId);
     if (!match) {

--- a/src/v1/kafka/consumers/match.topic.service.ts
+++ b/src/v1/kafka/consumers/match.topic.service.ts
@@ -5,6 +5,9 @@ import { TOURNAMENT_SOCKET_EVENTS } from '../../sockets/tournament/tournament.ev
 import TournamentPlayerCache from '../../storage/cache/tournament/tournament.player.cache.js';
 import TournamentMatchCache from '../../storage/cache/tournament/tournament.match.cache.js';
 import TournamentMetaCache from '../../storage/cache/tournament/tournament.meta.cache.js';
+import { HandleMatchResultType, matchResultMessageSchema } from '../schemas/match.topic.schema.js';
+import MatchRepository from '../../storage/database/prisma/match.repository.js';
+import { FastifyBaseLogger } from 'fastify';
 
 const handleMatchCreatedInputSchema = z.object({
   tournamentId: z.number(),
@@ -15,21 +18,6 @@ const handleMatchCreatedInputSchema = z.object({
 });
 type HandleMatchCreatedInputType = TypeOf<typeof handleMatchCreatedInputSchema>;
 
-const handleMatchResultInputSchema = z.object({
-  tournamentId: z.number(),
-  matchId: z.number(),
-  player1Id: z.number(),
-  player2Id: z.number(),
-  score: z.object({
-    player1: z.number(),
-    player2: z.number(),
-  }),
-  winnerId: z.number(),
-  loserId: z.number(),
-  round: z.number(),
-});
-type HandleMatchResultInputType = TypeOf<typeof handleMatchResultInputSchema>;
-
 export default class MatchTopicService {
   constructor(
     private readonly tournamentNamespace: Namespace,
@@ -37,6 +25,8 @@ export default class MatchTopicService {
     private readonly tournamentPlayerCache: TournamentPlayerCache,
     private readonly tournamentMatchCache: TournamentMatchCache,
     private readonly tournamentMetaCache: TournamentMetaCache,
+    private readonly matchRepository: MatchRepository,
+    private readonly logger: FastifyBaseLogger,
   ) {}
 
   async handleMatchCreated(messageValue: HandleMatchCreatedInputType): Promise<void> {
@@ -48,36 +38,39 @@ export default class MatchTopicService {
     }
   }
 
-  async handleMatchResult(messageValue: HandleMatchResultInputType): Promise<void> {
-    handleMatchResultInputSchema.parse(messageValue);
+  async handleMatchResult(messageValue: HandleMatchResultType): Promise<void> {
+    matchResultMessageSchema.parse(messageValue);
 
     // TODO: 매치 결과 DB에 저장 및 다음 라운드 반영
 
-    await this.tournamentPlayerCache.movePlayerToEliminated(
-      messageValue.tournamentId,
-      messageValue.loserId,
-    );
+    const match = await this.matchRepository.findById(messageValue.matchId);
+    if (!match) {
+      throw new Error(`Match with ID ${messageValue.matchId} not found`);
+    }
+    const tournamentId = match.tournamentId;
+
+    await this.tournamentPlayerCache.movePlayerToEliminated(tournamentId, messageValue.loserId);
 
     await this.tournamentMatchCache.removeMatchInRound(
-      messageValue.tournamentId,
-      messageValue.round,
+      tournamentId,
+      match.round,
       messageValue.matchId,
     );
 
-    if (
-      await this.tournamentMatchCache.isEmptyInRound(messageValue.tournamentId, messageValue.round)
-    ) {
-      await this.tournamentMetaCache.moveToNextRound(messageValue.tournamentId);
+    if (await this.tournamentMatchCache.isEmptyInRound(tournamentId, match.round)) {
+      await this.tournamentMetaCache.moveToNextRound(tournamentId);
     }
 
     this.tournamentNamespace
-      .to(`tournament:${messageValue.tournamentId}`)
+      .to(`tournament:${tournamentId}`)
       .emit(TOURNAMENT_SOCKET_EVENTS.GAME_RESULT, messageValue);
+    this.logger.info(`${tournamentId} tournament match result is sent:`, messageValue);
 
-    if (await this.tournamentMetaCache.isFinished(messageValue.tournamentId)) {
+    if (await this.tournamentMetaCache.isFinished(tournamentId)) {
       this.tournamentNamespace
-        .to(`tournament:${messageValue.tournamentId}`)
+        .to(`tournament:${tournamentId}`)
         .emit(TOURNAMENT_SOCKET_EVENTS.FINISHED);
+      this.logger.info(`Tournament ${tournamentId} has finished.`);
     }
   }
 

--- a/src/v1/kafka/consumers/match.topic.service.ts
+++ b/src/v1/kafka/consumers/match.topic.service.ts
@@ -41,17 +41,12 @@ export default class MatchTopicService {
   async handleMatchResult(messageValue: HandleMatchResultType): Promise<void> {
     matchResultMessageSchema.parse(messageValue);
 
-    await this.matchRepository.update(messageValue.matchId, {
+    const match = await this.matchRepository.update(messageValue.matchId, {
       player1Score: messageValue.score.player1,
       player2Score: messageValue.score.player2,
       winner: messageValue.winnerId,
       status: 'FINISHED',
     });
-
-    const match = await this.matchRepository.findById(messageValue.matchId);
-    if (!match) {
-      throw new Error(`Match with ID ${messageValue.matchId} not found`);
-    }
     const tournamentId = match.tournamentId;
 
     await this.tournamentPlayerCache.movePlayerToEliminated(tournamentId, messageValue.loserId);

--- a/src/v1/kafka/schemas/match.topic.schema.ts
+++ b/src/v1/kafka/schemas/match.topic.schema.ts
@@ -8,3 +8,16 @@ export const matchRequestMessageSchema = z.object({
   player2Id: z.number(),
   timestamp: z.string().datetime(),
 });
+
+export const matchResultMessageSchema = z.object({
+  matchId: z.number(),
+  player1Id: z.number(),
+  player2Id: z.number(),
+  score: z.object({
+    player1: z.number(),
+    player2: z.number(),
+  }),
+  winnerId: z.number(),
+  loserId: z.number(),
+});
+export type HandleMatchResultType = z.infer<typeof matchResultMessageSchema>;


### PR DESCRIPTION
## 📝 작업 내용

- match 서버에서 게임 종료시, match 관련 kafka 이벤트 발생
- 해당 게임결과를 kafka를 통해 받아와 해당 토너먼트에 참여한 사용자들에게 알림
- 그리고 게임 결과를 DB에 반영한다. 