### PR TITLE
[FEATURE] 게임 결과 조회 api 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev --name init && prisma generate",
+    "prisma:migrate": "prisma migrate dev",
     "prisma:reset": "prisma migrate reset --force && prisma generate",
     "prisma:deploy": "prisma migrate deploy && prisma generate",
     "prisma:seed": "prisma db seed",

--- a/prisma/migrations/20250903042926_add_update_and_create/migration.sql
+++ b/prisma/migrations/20250903042926_add_update_and_create/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `updated_at` to the `match` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `match`
+    ADD COLUMN `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    ADD COLUMN `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,9 @@ model Match {
   round        Int
   status       Status @default(NOT_STARTED)
 
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
   nextMatchId     Int?    @map("next_match_id")
   nextMatch       Match?  @relation("NextMatch", fields: [nextMatchId], references: [id])
   previousMatches Match[] @relation("NextMatch")

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ export default async function app(fastify: FastifyInstance) {
   setDecorate(fastify);
   setMiddleware(fastify);
 
-  fastify.register(routeV1, { prefix: '/v1' });
+  fastify.register(routeV1, { prefix: '/v1/game' });
 }
 
 function setErrorHandler(fastify: FastifyInstance) {

--- a/src/v1/apis/stats/schemas/game.stats.schema.ts
+++ b/src/v1/apis/stats/schemas/game.stats.schema.ts
@@ -32,11 +32,16 @@ export const ZDuelData = z.object({
   history: z.array(ZDuelHistoryItem),
 });
 
+export enum TournamentResultEnum {
+  WIN = 'WIN',
+  LOSS = 'LOSS',
+}
+
 export const ZTournamentHistoryItem = z.object({
   tournamentId: z.number().int().positive(),
   rounds: z.number().int().positive(),
   participants: z.array(ZUserMini).min(1),
-  myResult: z.enum(['WIN', 'LOSS']),
+  myResult: z.nativeEnum(TournamentResultEnum),
 });
 
 export const ZTournamentData = z.object({

--- a/src/v1/apis/stats/schemas/game.stats.schema.ts
+++ b/src/v1/apis/stats/schemas/game.stats.schema.ts
@@ -56,6 +56,9 @@ export enum StatsModeEnum {
   TOURNAMENT = 'tournament',
 }
 export const ZGetStatsQuery = z.object({ mode: z.nativeEnum(StatsModeEnum) });
+export const ZGetStatsParams = z.object({
+  userId: z.preprocess((val) => Number(val), z.number().int().nonnegative()),
+});
 
 export type UserMini = z.infer<typeof ZUserMini>;
 export type DuelData = z.infer<typeof ZDuelData>;

--- a/src/v1/apis/stats/schemas/game.stats.schema.ts
+++ b/src/v1/apis/stats/schemas/game.stats.schema.ts
@@ -45,9 +45,6 @@ export const ZTournamentData = z.object({
   history: z.array(ZTournamentHistoryItem),
 });
 
-export const ZGameStatsData = z.discriminatedUnion('mode', [ZDuelData, ZTournamentData]);
-
-export const ZGetStatsResponse = createResponseSchema(ZGameStatsData);
 export const ZGetDuelStatsResponse = createResponseSchema(ZDuelData);
 export const ZGetTournamentStatsResponse = createResponseSchema(ZTournamentData);
 

--- a/src/v1/apis/stats/schemas/game.stats.schema.ts
+++ b/src/v1/apis/stats/schemas/game.stats.schema.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+import { createResponseSchema } from '../../../common/schema/core.schema.js';
+
+export const ZUserMini = z.object({
+  id: z.number().int().nonnegative(),
+  nickname: z.string().min(1),
+});
+
+export const ZSummary = z.object({
+  wins: z.number().int().min(0),
+  losses: z.number().int().min(0),
+});
+
+export const ZDuelResult = z.object({
+  winnerId: z.number().int().nonnegative(),
+  scores: z.object({
+    player1: z.number().int().min(0),
+    player2: z.number().int().min(0),
+  }),
+});
+
+export const ZDuelHistoryItem = z.object({
+  date: z.string().datetime(),
+  player1: ZUserMini,
+  player2: ZUserMini,
+  result: ZDuelResult,
+});
+
+export const ZDuelData = z.object({
+  mode: z.literal('duel'),
+  summary: ZSummary,
+  history: z.array(ZDuelHistoryItem),
+});
+
+export const ZTournamentHistoryItem = z.object({
+  tournamentId: z.number().int().positive(),
+  rounds: z.number().int().positive(),
+  participants: z.array(ZUserMini).min(1),
+  myResult: z.enum(['WIN', 'LOSS']),
+});
+
+export const ZTournamentData = z.object({
+  mode: z.literal('tournament'),
+  summary: ZSummary,
+  history: z.array(ZTournamentHistoryItem),
+});
+
+export const ZGameStatsData = z.discriminatedUnion('mode', [ZDuelData, ZTournamentData]);
+
+export const ZGetStatsResponse = createResponseSchema(ZGameStatsData);
+export const ZGetDuelStatsResponse = createResponseSchema(ZDuelData);
+export const ZGetTournamentStatsResponse = createResponseSchema(ZTournamentData);
+
+export enum StatsModeEnum {
+  DUEL = 'duel',
+  TOURNAMENT = 'tournament',
+}
+export const ZGetStatsQuery = z.object({ mode: z.nativeEnum(StatsModeEnum) });
+
+export type UserMini = z.infer<typeof ZUserMini>;
+export type DuelData = z.infer<typeof ZDuelData>;
+export type TournamentData = z.infer<typeof ZTournamentData>;

--- a/src/v1/apis/stats/stats.controller.ts
+++ b/src/v1/apis/stats/stats.controller.ts
@@ -1,0 +1,48 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import StatsService from './stats.service.js';
+import {
+  StatsModeEnum,
+  ZGetDuelStatsResponse,
+  ZGetStatsQuery,
+  ZGetTournamentStatsResponse,
+} from './schemas/game.stats.schema.js';
+import { BadRequestException } from '../../common/exceptions/core.error.js';
+import { STATUS } from '../../common/constants/status.js';
+
+export default class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  getStats = async (request: FastifyRequest, reply: FastifyReply) => {
+    const query = ZGetStatsQuery.parse(request.query);
+    const userId = request.userId;
+    const mode = query.mode;
+
+    if (!userId || Number.isNaN(userId)) {
+      throw new Error('Invalid userId in request');
+    }
+
+    if (mode !== StatsModeEnum.DUEL && mode !== StatsModeEnum.TOURNAMENT) {
+      throw new BadRequestException('Invalid mode');
+    }
+
+    if (mode === StatsModeEnum.DUEL) {
+      const data = await this.statsService.getDuelStats(userId);
+      const body = {
+        status: STATUS.SUCCESS,
+        code: 200,
+        message: 'Request processed successfully',
+        data,
+      };
+      return reply.code(200).send(ZGetDuelStatsResponse.parse(body));
+    }
+
+    const data = await this.statsService.getTournamentStats(userId);
+    const body = {
+      status: STATUS.SUCCESS,
+      code: 200,
+      message: 'Request processed successfully',
+      data,
+    };
+    return reply.code(200).send(ZGetTournamentStatsResponse.parse(body));
+  };
+}

--- a/src/v1/apis/stats/stats.controller.ts
+++ b/src/v1/apis/stats/stats.controller.ts
@@ -3,6 +3,7 @@ import StatsService from './stats.service.js';
 import {
   StatsModeEnum,
   ZGetDuelStatsResponse,
+  ZGetStatsParams,
   ZGetStatsQuery,
   ZGetTournamentStatsResponse,
 } from './schemas/game.stats.schema.js';
@@ -14,8 +15,9 @@ export default class StatsController {
 
   getStats = async (request: FastifyRequest, reply: FastifyReply) => {
     const query = ZGetStatsQuery.parse(request.query);
-    const userId = request.userId;
+    const params = ZGetStatsParams.parse(request.params);
     const mode = query.mode;
+    const userId = params.userId;
 
     if (!userId || Number.isNaN(userId)) {
       throw new Error('Invalid userId in request');

--- a/src/v1/apis/stats/stats.controller.ts
+++ b/src/v1/apis/stats/stats.controller.ts
@@ -8,7 +8,6 @@ import {
   ZGetTournamentStatsResponse,
 } from './schemas/game.stats.schema.js';
 import { STATUS } from '../../common/constants/status.js';
-import { BadRequestException } from '../../common/exceptions/core.error.js';
 
 export default class StatsController {
   constructor(private readonly statsService: StatsService) {}
@@ -19,25 +18,24 @@ export default class StatsController {
     const mode = query.mode;
     const userId = params.userId;
 
-    let data;
-    let responseSchema;
-
     if (mode === StatsModeEnum.DUEL) {
-      data = await this.statsService.getDuelStats(userId);
-      responseSchema = ZGetDuelStatsResponse;
-    } else if (mode === StatsModeEnum.TOURNAMENT) {
-      data = await this.statsService.getTournamentStats(userId);
-      responseSchema = ZGetTournamentStatsResponse;
-    } else {
-      throw new BadRequestException('Invalid mode parameter');
+      const data = await this.statsService.getDuelStats(userId);
+      const body = {
+        status: STATUS.SUCCESS,
+        code: 200,
+        message: 'Request processed successfully',
+        data,
+      };
+      return reply.code(200).send(ZGetDuelStatsResponse.parse(body));
     }
 
+    const data = await this.statsService.getTournamentStats(userId);
     const body = {
       status: STATUS.SUCCESS,
       code: 200,
       message: 'Request processed successfully',
       data,
     };
-    return reply.code(200).send(responseSchema.parse(body));
+    return reply.code(200).send(ZGetTournamentStatsResponse.parse(body));
   };
 }

--- a/src/v1/apis/stats/stats.controller.ts
+++ b/src/v1/apis/stats/stats.controller.ts
@@ -8,6 +8,7 @@ import {
   ZGetTournamentStatsResponse,
 } from './schemas/game.stats.schema.js';
 import { STATUS } from '../../common/constants/status.js';
+import { BadRequestException } from '../../common/exceptions/core.error.js';
 
 export default class StatsController {
   constructor(private readonly statsService: StatsService) {}
@@ -18,24 +19,25 @@ export default class StatsController {
     const mode = query.mode;
     const userId = params.userId;
 
+    let data;
+    let responseSchema;
+
     if (mode === StatsModeEnum.DUEL) {
-      const data = await this.statsService.getDuelStats(userId);
-      const body = {
-        status: STATUS.SUCCESS,
-        code: 200,
-        message: 'Request processed successfully',
-        data,
-      };
-      return reply.code(200).send(ZGetDuelStatsResponse.parse(body));
+      data = await this.statsService.getDuelStats(userId);
+      responseSchema = ZGetDuelStatsResponse;
+    } else if (mode === StatsModeEnum.TOURNAMENT) {
+      data = await this.statsService.getTournamentStats(userId);
+      responseSchema = ZGetTournamentStatsResponse;
+    } else {
+      throw new BadRequestException('Invalid mode parameter');
     }
 
-    const data = await this.statsService.getTournamentStats(userId);
     const body = {
       status: STATUS.SUCCESS,
       code: 200,
       message: 'Request processed successfully',
       data,
     };
-    return reply.code(200).send(ZGetTournamentStatsResponse.parse(body));
+    return reply.code(200).send(responseSchema.parse(body));
   };
 }

--- a/src/v1/apis/stats/stats.controller.ts
+++ b/src/v1/apis/stats/stats.controller.ts
@@ -7,7 +7,6 @@ import {
   ZGetStatsQuery,
   ZGetTournamentStatsResponse,
 } from './schemas/game.stats.schema.js';
-import { BadRequestException } from '../../common/exceptions/core.error.js';
 import { STATUS } from '../../common/constants/status.js';
 
 export default class StatsController {
@@ -18,14 +17,6 @@ export default class StatsController {
     const params = ZGetStatsParams.parse(request.params);
     const mode = query.mode;
     const userId = params.userId;
-
-    if (!userId || Number.isNaN(userId)) {
-      throw new Error('Invalid userId in request');
-    }
-
-    if (mode !== StatsModeEnum.DUEL && mode !== StatsModeEnum.TOURNAMENT) {
-      throw new BadRequestException('Invalid mode');
-    }
 
     if (mode === StatsModeEnum.DUEL) {
       const data = await this.statsService.getDuelStats(userId);

--- a/src/v1/apis/stats/stats.route.ts
+++ b/src/v1/apis/stats/stats.route.ts
@@ -1,0 +1,28 @@
+import { FastifyInstance } from 'fastify';
+import { addRoutes, Route } from '../../../plugins/router.js';
+import { ZGetStatsQuery, ZGetStatsResponse } from './schemas/game.stats.schema.js';
+import StatsController from './stats.controller.js';
+
+export default async function statsRoutes(fastify: FastifyInstance) {
+  const gameStatsController: StatsController = fastify.diContainer.resolve('statsController');
+
+  const routes: Array<Route> = [
+    {
+      method: 'GET',
+      url: '/:userId',
+      handler: gameStatsController.getStats,
+      options: {
+        auth: true,
+        description: 'Get game stats by user and mode (duel | tournament)',
+        schema: {
+          querystring: ZGetStatsQuery,
+          response: {
+            200: ZGetStatsResponse,
+          },
+        },
+      },
+    },
+  ];
+
+  await addRoutes(fastify, routes);
+}

--- a/src/v1/apis/stats/stats.route.ts
+++ b/src/v1/apis/stats/stats.route.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { addRoutes, Route } from '../../../plugins/router.js';
-import { ZGetStatsQuery, ZGetStatsResponse } from './schemas/game.stats.schema.js';
+import { ZGetStatsParams, ZGetStatsQuery, ZGetStatsResponse } from './schemas/game.stats.schema.js';
 import StatsController from './stats.controller.js';
 
 export default async function statsRoutes(fastify: FastifyInstance) {
@@ -16,6 +16,7 @@ export default async function statsRoutes(fastify: FastifyInstance) {
         description: 'Get game stats by user and mode (duel | tournament)',
         schema: {
           querystring: ZGetStatsQuery,
+          params: ZGetStatsParams,
           response: {
             200: ZGetStatsResponse,
           },

--- a/src/v1/apis/stats/stats.route.ts
+++ b/src/v1/apis/stats/stats.route.ts
@@ -1,7 +1,13 @@
 import { FastifyInstance } from 'fastify';
 import { addRoutes, Route } from '../../../plugins/router.js';
-import { ZGetStatsParams, ZGetStatsQuery, ZGetStatsResponse } from './schemas/game.stats.schema.js';
+import {
+  ZGetDuelStatsResponse,
+  ZGetStatsParams,
+  ZGetStatsQuery,
+  ZGetTournamentStatsResponse,
+} from './schemas/game.stats.schema.js';
 import StatsController from './stats.controller.js';
+import { z } from 'zod';
 
 export default async function statsRoutes(fastify: FastifyInstance) {
   const gameStatsController: StatsController = fastify.diContainer.resolve('statsController');
@@ -18,7 +24,7 @@ export default async function statsRoutes(fastify: FastifyInstance) {
           querystring: ZGetStatsQuery,
           params: ZGetStatsParams,
           response: {
-            200: ZGetStatsResponse,
+            200: z.union([ZGetDuelStatsResponse, ZGetTournamentStatsResponse]),
           },
         },
       },

--- a/src/v1/apis/stats/stats.service.ts
+++ b/src/v1/apis/stats/stats.service.ts
@@ -1,0 +1,111 @@
+import MatchRepository from '../../storage/database/prisma/match.repository.js';
+import TournamentRepository from '../../storage/database/prisma/tournament.repository.js';
+import UserServiceClient from '../../client/user.service.client.js';
+import { FastifyBaseLogger } from 'fastify';
+import {
+  DuelData,
+  TournamentData,
+  ZDuelData,
+  ZTournamentData,
+  UserMini,
+} from './schemas/game.stats.schema.js';
+import { Match, Player } from '@prisma/client';
+import { TournamentWithPlayers } from '../../storage/database/interfaces/tournament.repository.interface.js';
+
+export default class StatsService {
+  constructor(
+    private readonly matchRepository: MatchRepository,
+    private readonly tournamentRepository: TournamentRepository,
+    private readonly userServiceClient: UserServiceClient,
+    private readonly logger: FastifyBaseLogger,
+  ) {}
+
+  private async getUserMiniCached(cache: Map<number, UserMini>, userId: number): Promise<UserMini> {
+    if (cache.has(userId)) return cache.get(userId)!;
+    try {
+      const user = await this.userServiceClient.getUserInfo(userId);
+      const mini: UserMini = { id: user.id, nickname: user.nickname };
+      cache.set(userId, mini);
+      return mini;
+    } catch (e) {
+      this.logger.warn(e, `Failed to fetch user info for ${userId}, using fallback`);
+      const mini: UserMini = { id: userId, nickname: String(userId) };
+      cache.set(userId, mini);
+      return mini;
+    }
+  }
+
+  async getDuelStats(userId: number): Promise<DuelData> {
+    const [{ wins, losses }, matches] = await Promise.all([
+      this.matchRepository.countWinsLossesInDuelByUser(userId),
+      this.matchRepository.findFinishedMatchesByUserInDuel(userId),
+    ]);
+
+    const userCache = new Map<number, UserMini>();
+
+    const history = await Promise.all(
+      matches.map(async (match: Match) => {
+        const p1Id = match.player1Id ?? 0;
+        const p2Id = match.player2Id ?? 0;
+        const [p1, p2] = await Promise.all([
+          this.getUserMiniCached(userCache, p1Id),
+          this.getUserMiniCached(userCache, p2Id),
+        ]);
+        return {
+          date: match.createdAt?.toISOString?.() ?? new Date().toISOString(),
+          player1: p1,
+          player2: p2,
+          result: {
+            winnerId: match.winner ?? 0,
+            scores: {
+              player1: match.player1Score ?? 0,
+              player2: match.player2Score ?? 0,
+            },
+          },
+        };
+      }),
+    );
+
+    const data: DuelData = {
+      mode: 'duel',
+      summary: { wins: wins ?? 0, losses: losses ?? 0 },
+      history,
+    } as DuelData;
+
+    return ZDuelData.parse(data);
+  }
+
+  async getTournamentStats(userId: number): Promise<TournamentData> {
+    const [tournaments, wins] = await Promise.all([
+      this.tournamentRepository.findTournamentsByUser(userId),
+      this.tournamentRepository.countTournamentWinsByUser(userId),
+    ]);
+
+    const userCache = new Map<number, UserMini>();
+
+    const history = await Promise.all(
+      tournaments.map(async (tournament: TournamentWithPlayers) => {
+        const participantIds = (tournament.players || []).map((player: Player) => player.userId);
+        const participants = await Promise.all(
+          participantIds.map((pid: number) => this.getUserMiniCached(userCache, pid)),
+        );
+        return {
+          tournamentId: tournament.id,
+          rounds: tournament.size,
+          participants,
+          myResult: tournament.winnerId === userId ? 'WIN' : 'LOSS',
+        };
+      }),
+    );
+
+    const losses = Math.max(0, (tournaments?.length ?? 0) - (wins ?? 0));
+
+    const data: TournamentData = {
+      mode: 'tournament',
+      summary: { wins: wins ?? 0, losses },
+      history,
+    } as TournamentData;
+
+    return ZTournamentData.parse(data);
+  }
+}

--- a/src/v1/apis/stats/stats.service.ts
+++ b/src/v1/apis/stats/stats.service.ts
@@ -11,6 +11,7 @@ import {
 } from './schemas/game.stats.schema.js';
 import { Match, Player } from '@prisma/client';
 import { TournamentWithPlayers } from '../../storage/database/interfaces/tournament.repository.interface.js';
+import { InternalServerException } from '../../common/exceptions/core.error.js';
 
 export default class StatsService {
   constructor(
@@ -45,21 +46,22 @@ export default class StatsService {
 
     const history = await Promise.all(
       matches.map(async (match: Match) => {
-        const p1Id = match.player1Id ?? 0;
-        const p2Id = match.player2Id ?? 0;
+        if (!match.player1Id || !match.player2Id) {
+          throw new InternalServerException('Match is missing player1Id or player2Id');
+        }
         const [p1, p2] = await Promise.all([
-          this.getUserMiniCached(userCache, p1Id),
-          this.getUserMiniCached(userCache, p2Id),
+          this.getUserMiniCached(userCache, match.player1Id),
+          this.getUserMiniCached(userCache, match.player2Id),
         ]);
         return {
-          date: match.createdAt?.toISOString?.() ?? new Date().toISOString(),
+          date: match.createdAt.toISOString(),
           player1: p1,
           player2: p2,
           result: {
-            winnerId: match.winner ?? 0,
+            winnerId: match.winner,
             scores: {
-              player1: match.player1Score ?? 0,
-              player2: match.player2Score ?? 0,
+              player1: match.player1Score,
+              player2: match.player2Score,
             },
           },
         };

--- a/src/v1/apis/stats/stats.service.ts
+++ b/src/v1/apis/stats/stats.service.ts
@@ -87,7 +87,7 @@ export default class StatsService {
 
     const history = await Promise.all(
       tournaments.map(async (tournament: TournamentWithPlayers) => {
-        const participantIds = (tournament.players || []).map((player: Player) => player.userId);
+        const participantIds = tournament.players.map((player: Player) => player.userId);
         const participants = await Promise.all(
           participantIds.map((pid: number) => this.getUserMiniCached(userCache, pid)),
         );

--- a/src/v1/apis/stats/stats.service.ts
+++ b/src/v1/apis/stats/stats.service.ts
@@ -8,6 +8,8 @@ import {
   ZDuelData,
   ZTournamentData,
   UserMini,
+  TournamentResultEnum,
+  StatsModeEnum,
 } from './schemas/game.stats.schema.js';
 import { Match, Player } from '@prisma/client';
 import { TournamentWithPlayers } from '../../storage/database/interfaces/tournament.repository.interface.js';
@@ -49,6 +51,12 @@ export default class StatsService {
         if (!match.player1Id || !match.player2Id) {
           throw new InternalServerException('Match is missing player1Id or player2Id');
         }
+        if (match.winner === null) {
+          throw new InternalServerException('Match is missing winner');
+        }
+        if (match.player1Score === null || match.player2Score === null) {
+          throw new InternalServerException('Match is missing player scores');
+        }
         const [p1, p2] = await Promise.all([
           this.getUserMiniCached(userCache, match.player1Id),
           this.getUserMiniCached(userCache, match.player2Id),
@@ -69,10 +77,10 @@ export default class StatsService {
     );
 
     const data: DuelData = {
-      mode: 'duel',
-      summary: { wins: wins ?? 0, losses: losses ?? 0 },
+      mode: StatsModeEnum.DUEL,
+      summary: { wins: wins, losses: losses },
       history,
-    } as DuelData;
+    };
 
     return ZDuelData.parse(data);
   }
@@ -95,7 +103,8 @@ export default class StatsService {
           tournamentId: tournament.id,
           rounds: tournament.size,
           participants,
-          myResult: tournament.winnerId === userId ? 'WIN' : 'LOSS',
+          myResult:
+            tournament.winnerId === userId ? TournamentResultEnum.WIN : TournamentResultEnum.LOSS,
         };
       }),
     );
@@ -103,10 +112,10 @@ export default class StatsService {
     const losses = Math.max(0, tournaments.length - wins);
 
     const data: TournamentData = {
-      mode: 'tournament',
+      mode: StatsModeEnum.TOURNAMENT,
       summary: { wins: wins, losses },
       history,
-    } as TournamentData;
+    };
 
     return ZTournamentData.parse(data);
   }

--- a/src/v1/apis/stats/stats.service.ts
+++ b/src/v1/apis/stats/stats.service.ts
@@ -29,7 +29,7 @@ export default class StatsService {
       cache.set(userId, mini);
       return mini;
     } catch (e) {
-      this.logger.warn(e, `Failed to fetch user info for ${userId}, using fallback`);
+      this.logger.error(e, `Failed to fetch user info for ${userId}, using fallback`);
       const mini: UserMini = { id: userId, nickname: String(userId) };
       cache.set(userId, mini);
       return mini;

--- a/src/v1/apis/stats/stats.service.ts
+++ b/src/v1/apis/stats/stats.service.ts
@@ -100,11 +100,11 @@ export default class StatsService {
       }),
     );
 
-    const losses = Math.max(0, (tournaments?.length ?? 0) - (wins ?? 0));
+    const losses = Math.max(0, tournaments.length - wins);
 
     const data: TournamentData = {
       mode: 'tournament',
-      summary: { wins: wins ?? 0, losses },
+      summary: { wins: wins, losses },
       history,
     } as TournamentData;
 

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -1,7 +1,9 @@
 import { FastifyInstance } from 'fastify';
 
 import gameRoutes from './apis/game/games.route.js';
+import statsRoutes from './apis/stats/stats.route.js';
 
 export default async function routeV1(fastify: FastifyInstance) {
-  fastify.register(gameRoutes, { prefix: '/game' });
+  fastify.register(gameRoutes, { prefix: '/' });
+  fastify.register(statsRoutes, { prefix: '/stats' });
 }

--- a/src/v1/storage/database/interfaces/match.repository.interface.ts
+++ b/src/v1/storage/database/interfaces/match.repository.interface.ts
@@ -9,5 +9,12 @@ export default interface MatchRepositoryInterface
     tx?: Prisma.TransactionClient,
   ): Promise<Match[]>;
 
+  // 특정 토너먼트의 모든 매치 조회
   findManyByTournamentId(tournamentId: number, tx?: Prisma.TransactionClient): Promise<Match[]>;
+
+  // 듀얼(토너먼트 사이즈 2)에서 특정 유저가 참여하고 종료된 매치 조회 (최근순)
+  findFinishedMatchesByUserInDuel(userId: number): Promise<Match[]>;
+
+  // 듀얼에서 특정 유저의 승/패 수 집계
+  countWinsLossesInDuelByUser(userId: number): Promise<{ wins: number; losses: number }>;
 }

--- a/src/v1/storage/database/interfaces/tournament.repository.interface.ts
+++ b/src/v1/storage/database/interfaces/tournament.repository.interface.ts
@@ -1,9 +1,24 @@
 import { Prisma, Tournament } from '@prisma/client';
 import { BaseRepositoryInterface } from './base.repository.interface.js';
 
+export type TournamentWithPlayers = Prisma.TournamentGetPayload<{
+  include: {
+    players: true;
+  };
+}>;
+
 export default interface TournamentRepositoryInterface
   extends BaseRepositoryInterface<
     Tournament,
     Prisma.TournamentCreateInput,
     Prisma.TournamentUpdateInput
-  > {}
+  > {
+  // 특정 유저가 참가한 모든 토너먼트 조회
+  findTournamentsByUser(userId: number): Promise<TournamentWithPlayers[]>;
+
+  // 특정 유저가 참가한 모든 1:1 토너먼트 조회
+  findDuelTournamentsByUser(userId: number): Promise<TournamentWithPlayers[]>;
+
+  // 특정 유저의 토너먼트 우승 횟수
+  countTournamentWinsByUser(userId: number): Promise<number>;
+}

--- a/src/v1/storage/database/prisma/match.repository.ts
+++ b/src/v1/storage/database/prisma/match.repository.ts
@@ -55,4 +55,38 @@ export default class MatchRepository implements MatchRepositoryInterface {
       },
     });
   }
+
+  async findFinishedMatchesByUserInDuel(userId: number): Promise<Match[]> {
+    return this.prisma.match.findMany({
+      where: {
+        status: 'FINISHED',
+        tournament: { size: 2 },
+        OR: [{ player1Id: userId }, { player2Id: userId }],
+      },
+      orderBy: { id: 'desc' },
+    });
+  }
+
+  async countWinsLossesInDuelByUser(userId: number): Promise<{ wins: number; losses: number }> {
+    const [wins, losses] = await Promise.all([
+      this.prisma.match.count({
+        where: {
+          status: 'FINISHED',
+          tournament: { size: 2 },
+          winner: userId,
+        },
+      }),
+      this.prisma.match.count({
+        where: {
+          status: 'FINISHED',
+          tournament: { size: 2 },
+          OR: [{ player1Id: userId }, { player2Id: userId }],
+          winner: { not: null },
+          NOT: { winner: userId },
+        },
+      }),
+    ]);
+
+    return { wins, losses };
+  }
 }

--- a/src/v1/storage/database/prisma/tournament.repository.ts
+++ b/src/v1/storage/database/prisma/tournament.repository.ts
@@ -1,4 +1,6 @@
-import TournamentRepositoryInterface from '../interfaces/tournament.repository.interface.js';
+import TournamentRepositoryInterface, {
+  TournamentWithPlayers,
+} from '../interfaces/tournament.repository.interface.js';
 import { Prisma, PrismaClient, Tournament } from '@prisma/client';
 
 export default class TournamentRepository implements TournamentRepositoryInterface {
@@ -28,5 +30,49 @@ export default class TournamentRepository implements TournamentRepositoryInterfa
   ): Promise<Tournament> {
     const client = tx || this.prisma;
     return client.tournament.update({ where: { id }, data });
+  }
+
+  async findTournamentsByUser(userId: number): Promise<TournamentWithPlayers[]> {
+    return this.prisma.tournament.findMany({
+      where: {
+        players: {
+          some: { userId },
+        },
+      },
+      include: {
+        players: true,
+      },
+      orderBy: {
+        id: 'desc',
+      },
+    });
+  }
+
+  findDuelTournamentsByUser(userId: number): Promise<TournamentWithPlayers[]> {
+    return this.prisma.tournament.findMany({
+      where: {
+        players: {
+          some: { userId },
+        },
+        size: 2,
+      },
+      include: {
+        players: true,
+      },
+      orderBy: {
+        id: 'desc',
+      },
+    });
+  }
+
+  async countTournamentWinsByUser(userId: number): Promise<number> {
+    return this.prisma.tournament.count({
+      where: {
+        winnerId: userId,
+        size: {
+          gt: 2,
+        },
+      },
+    });
   }
 }

--- a/src/v1/storage/database/prisma/tournament.repository.ts
+++ b/src/v1/storage/database/prisma/tournament.repository.ts
@@ -38,6 +38,9 @@ export default class TournamentRepository implements TournamentRepositoryInterfa
         players: {
           some: { userId },
         },
+        size: {
+          gt: 2,
+        },
         status: 'FINISHED',
       },
       include: {

--- a/src/v1/storage/database/prisma/tournament.repository.ts
+++ b/src/v1/storage/database/prisma/tournament.repository.ts
@@ -38,6 +38,7 @@ export default class TournamentRepository implements TournamentRepositoryInterfa
         players: {
           some: { userId },
         },
+        status: 'FINISHED',
       },
       include: {
         players: true,
@@ -55,6 +56,7 @@ export default class TournamentRepository implements TournamentRepositoryInterfa
           some: { userId },
         },
         size: 2,
+        status: 'FINISHED',
       },
       include: {
         players: true,
@@ -72,6 +74,7 @@ export default class TournamentRepository implements TournamentRepositoryInterfa
         size: {
           gt: 2,
         },
+        status: 'FINISHED',
       },
     });
   }


### PR DESCRIPTION
## 📝 작업 내용

- 특정 유저의 게임-결과(게임 히스토리)를 조회하는 api를 구현하였습니다.
- endpoint: `/api/v1/game/stats/{userId}`
- query parameter에 따라 결과를 반환합니다.
- 1:1 결과를 받기 위해서는 `mode`에 `duel`을, 토너먼트 결과를 받기 위해서는 `mode`에 `tournament`를 넣으면 됩니다.