### PR TITLE
[FIX] mode query 소문자 처리 추가

### DIFF
--- a/src/v1/apis/stats/schemas/game.stats.schema.ts
+++ b/src/v1/apis/stats/schemas/game.stats.schema.ts
@@ -57,7 +57,12 @@ export enum StatsModeEnum {
   DUEL = 'duel',
   TOURNAMENT = 'tournament',
 }
-export const ZGetStatsQuery = z.object({ mode: z.nativeEnum(StatsModeEnum) });
+export const ZGetStatsQuery = z.object({
+  mode: z.preprocess(
+    (str) => (typeof str === 'string' ? str.toLowerCase() : str),
+    z.nativeEnum(StatsModeEnum),
+  ),
+});
 export const ZGetStatsParams = z.object({
   userId: z.preprocess((val) => Number(val), z.number().int().nonnegative()),
 });


### PR DESCRIPTION
## 📝 작업 내용

- `/api/v1/game/stats/{userId}` 는 query로 `mode`를 받습니다.
- 이떄 `mode`의 값은 enum인데, 이때 대소문자를 구분하지 않도록 수정하였습니다.